### PR TITLE
Add support for Docker for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ You can control the startup mode by using ```SEVEN_DAYS_TO_DIE_START_MODE```. Th
 Note that you should also enable telnet and optionally modify the ```SEVEN_DAYS_TO_DIE_TELNET_PORT``` and ```SEVEN_DAYS_TO_DIE_TELNET_PASSWORD``` environment variables accordingly, so the container can properly send the shutdown command to the server when the proper signal has been received (it uses telnet for this).
 
 One additional feature you can enable is fully automatic updates, meaning that once a server update hits Steam, it'll restart the server and trigger the automatic update. You can enable this by setting ```SEVEN_DAYS_TO_DIE_UPDATE_CHECKING``` to ```"1"```.
+
+
+If using Docker for Windows make sure to add the Drive letter the git repository is located on, this is doen through the GUI.

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Note that you should also enable telnet and optionally modify the ```SEVEN_DAYS_
 One additional feature you can enable is fully automatic updates, meaning that once a server update hits Steam, it'll restart the server and trigger the automatic update. You can enable this by setting ```SEVEN_DAYS_TO_DIE_UPDATE_CHECKING``` to ```"1"```.
 
 
-If using Docker for Windows make sure to add the Drive letter the git repository is located on, this is doen through the GUI.
+If using Docker for Windows *and* the File System passthrough option, make sure to add the git repo drive letter as a shared drive through the Docker GUI.

--- a/docker_build.ps1
+++ b/docker_build.ps1
@@ -1,0 +1,3 @@
+#pwsh command to build docker image
+
+docker build -t didstopia/7dtd-server:latest .

--- a/docker_build_force.ps1
+++ b/docker_build_force.ps1
@@ -1,0 +1,3 @@
+#pwsh command to force docker image build
+
+docker build --no-cache -t didstopia/7dtd-server:latest .

--- a/docker_run.ps1
+++ b/docker_run.ps1
@@ -1,0 +1,10 @@
+#you need to allow docker access to the shared drive the git repo is on, this is done through the GUI
+
+#run build first
+.\docker_build.ps1
+
+#get pwd.. because Get-Location doesn't work
+$pwd = (Get-Location).tostring().Replace('\','/')
+
+#start command
+docker run --rm -it -p 26900:26900/tcp -p 26900:26900/udp -p 26901:26901/udp -p 26902:26902/udp -p 3000:3000/tcp -p 8080:8080/tcp -p 8081:8081/tcp -e SEVEN_DAYS_TO_DIE_UPDATE_CHECKING="1" -e SEVEN_DAYS_TO_DIE_SERVER_STARTUP_ARGUMENTS="-configfile=server_data/serverconfig.xml -logfile /dev/stdout -quit -batchmode -nographics -dedicated" -e SEVEN_DAYS_TO_DIE_UPDATE_BRANCH="latest-experimental" -v ${pwd}/7dtd_data:/steamcmd/7dtd didstopia/7dtd-server:latest


### PR DESCRIPTION
Converted the bash scripts into ps1 (powershell) scripts. Some workarounds had to be made for FS passthrough on docker_run.ps1 in order to get it to work properly. An additional step is required by sharing the local drive the git repo is on to allow FS passthrough on Docker for Windows.