### PR TITLE
Fix steam ID in update check

### DIFF
--- a/update_check.sh
+++ b/update_check.sh
@@ -27,7 +27,7 @@ if [ -f "/root/Steam/appcache/appinfo.vdf" ]; then
 fi
 
 # Get the new build id directly from Steam
-NEW_BUILDID="$(./steamcmd/steamcmd.sh +login anonymous +app_info_update 1 +app_info_print "258550" +quit | grep -EA 1000 "^\s+\"branches\"$" | grep -EA 5 "^\s+\"$SEVEN_DAYS_TO_DIE\"$" | grep -m 1 -EB 10 "^\s+}$" | grep -E "^\s+\"buildid\"\s+" | tr '[:blank:]"' ' ' | tr -s ' ' | sed "s/ buildid //g" | xargs)"
+NEW_BUILDID="$(./steamcmd/steamcmd.sh +login anonymous +app_info_update 1 +app_info_print "294420" +quit | grep -EA 1000 "^\s+\"branches\"$" | grep -EA 5 "^\s+\"$SEVEN_DAYS_TO_DIE\"$" | grep -m 1 -EB 10 "^\s+}$" | grep -E "^\s+\"buildid\"\s+" | tr '[:blank:]"' ' ' | tr -s ' ' | sed "s/ buildid //g" | xargs)"
 
 # Check that we actually got a new build id
 STRING_SIZE=${#NEW_BUILDID}


### PR DESCRIPTION
Previous ID offered updates for Rust Dedicated Server (https://steamdb.info/app/258550/) instead of 7 Days to Die Dedicated Server (https://steamdb.info/app/294420/ )