### PR TITLE
Fix warning on app install

### DIFF
--- a/install.txt
+++ b/install.txt
@@ -1,5 +1,5 @@
 @sSteamCmdForcePlatformType linux
-login anonymous
 force_install_dir /steamcmd/7dtd
+login anonymous
 app_update 294420 validate
 quit


### PR DESCRIPTION
From the logs
```
force_install_dir /steamcmd/7dtd
Please use force_install_dir before logon!
```

Switching the login to after force_install_dir fixes that warning.